### PR TITLE
intercom: settings icprivacy, icallow... can be set per account

### DIFF
--- a/modules/intercom/incoming.c
+++ b/modules/intercom/incoming.c
@@ -60,36 +60,6 @@ static bool is_intercom(const struct pl *name, const struct pl *val)
 }
 
 
-/**
- * Fetch parameter from a PL string. The separator can be specified
- *
- * @param pl    PL string to search
- * @param pname Parameter name
- * @param sep   Separator
- * @param val   Parameter value, set on return
- *
- * @return true if found, false if not found
- */
-static bool fmt_param_sep_get(const struct pl *pl, const char *pname, char sep,
-		struct pl *val)
-{
-	struct pl semi;
-	char expr[128];
-
-	if (!pl || !pname)
-		return false;
-
-	(void)re_snprintf(expr, sizeof(expr),
-		  "[%c]*[ \t\r\n]*%s[ \t\r\n]*=[ \t\r\n]*[~ \t\r\n%c]+",
-		  sep, pname, sep);
-
-	if (re_regex(pl->p, pl->l, expr, &semi, NULL, NULL, NULL, val))
-		return false;
-
-	return semi.l > 0 || pl->p == semi.p;
-}
-
-
 static bool account_extra_bool(const struct account *acc, const char *name,
 		bool *set)
 {

--- a/modules/intercom/intercom.c
+++ b/modules/intercom/intercom.c
@@ -33,6 +33,13 @@
  * icallow_force                no
  * icallow_surveil              no
  *
+ * Extra accounts address parameters:
+ * The settings for icprivacy, icallow_announce, icallow_force, icallow_surveil
+ * can be overwritten by specifying address parameter `extra` in accounts file.
+ * The value for extra is a comma-separated list of settings. E.g.:
+ *
+ * <sip:A@localhost>;sip_autoanswer=yes;extra=icprivacy=yes,icallow_announce=no
+ *
  */
 
 


### PR DESCRIPTION
`extra` parameter in accounts overrides settings in config.

Should we move `fmt_param_sep_get()` to libre?

edit: Opened a PR for re https://github.com/baresip/re/pull/117 . If it is accepted this PR could be simplified. So put this to draft.