### PR TITLE
Fix new ausrc alloc

### DIFF
--- a/modules/auloop/auloop.c
+++ b/modules/auloop/auloop.c
@@ -325,7 +325,7 @@ static int auloop_reset(struct audio_loop *al, uint32_t srate, uint8_t ch)
 	ausrc_prm.fmt        = al->fmt;
 
 	err = ausrc_alloc(&al->ausrc, baresip_ausrcl(),
-			  NULL, cfg->audio.src_mod,
+			  cfg->audio.src_mod,
 			  &ausrc_prm, cfg->audio.src_dev,
 			  src_read_handler, error_handler, al);
 	if (err) {

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -662,7 +662,7 @@ static int vsrc_reopen(struct video_loop *vl, const struct vidsz *sz)
 
 	vl->vsrc = mem_deref(vl->vsrc);
 	err = vidsrc_alloc(&vl->vsrc, baresip_vidsrcl(),
-			   vl->cfg.src_mod, NULL, &vl->srcprm, sz,
+			   vl->cfg.src_mod, &vl->srcprm, sz,
 			   NULL, vl->cfg.src_dev, vidsrc_frame_handler,
 			   vidsrc_packet_handler,
 			   NULL, vl);


### PR DESCRIPTION
Update the usage of functions ausrc_alloc() andf vidsrc_alloc() changed by commit "remove struct media_ctx (#1632)" 51f1ae02233cab40d37ffe346e42489aae276d1f
