### PR TITLE
intercom: add video preview call

### DIFF
--- a/modules/intercom/intercom.c
+++ b/modules/intercom/intercom.c
@@ -33,6 +33,9 @@
  * icallow_force                no
  * icallow_surveil              no
  *
+ * icpreview_subject            preview
+ * icpreview_aufile             preview.wav
+ *
  * Extra accounts address parameters:
  * The settings for icprivacy, icallow_announce, icallow_force, icallow_surveil
  * can be overwritten by specifying address parameter `extra` in accounts file.


### PR DESCRIPTION
The callee is able to identify an intercom call with configured Subject header and answers with a SIP 183 Session Progress for
requesting early video.

e.g.:
```
INVITE sip:10.1.0.2 SIP/2.0
...
Subject: preview/12334123
```
with configured

```
icpreview_subject     preview
```
lets the callee request early video.