### PR TITLE
ua: send new event UA_EVENT_CREATE at successful ua allocation

### DIFF
--- a/modules/intercom/incoming.c
+++ b/modules/intercom/incoming.c
@@ -276,6 +276,10 @@ void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	switch (ev) {
 
+	case UA_EVENT_CREATE:
+		ua_add_xhdr_filter(ua, "Subject");
+		break;
+
 	case UA_EVENT_CALL_INCOMING:
 
 		hdrs = call_get_custom_hdrs(call);


### PR DESCRIPTION
This PR depends on [baresip/PR1840](https://github.com/baresip/baresip/pull/1840)