### PR TITLE
cmake: avoid include and link directory /usr/local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,13 +87,10 @@ add_definitions(${RE_DEFINITIONS})
 include_directories(
   include
   src
-  /usr/local/include
   ${RE_INCLUDE_DIRS}
   ${BARESIP_INCLUDE_DIRS}
   ${OPENSSL_INCLUDE_DIR}
 )
-
-link_directories(/usr/local/lib)
 
 if(MOD_PATH)
   add_definitions(-DMOD_PATH="${MOD_PATH}")


### PR DESCRIPTION
Including /usr/... is unsafe for cross-compilation

similar to: https://github.com/baresip/baresip/pull/2506
