### PR TITLE
ci/build: add and fix baresip-apps build

### DIFF
--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -8,7 +8,6 @@
 #include <string.h>
 #include <time.h>
 #include <re.h>
-#include <re_h264.h>
 #include <rem.h>
 #include <baresip.h>
 


### PR DESCRIPTION
`#include <re_h264.h>` was added to `include/re.h`

relates to: https://github.com/baresip/baresip/pull/2986