### PR TITLE
multicast: fix receiver for IPv6

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -649,7 +649,7 @@ static int module_read_config(void)
 	err = conf_apply(conf_cur(), "multicast_listener",
 		module_read_config_handler, &prio);
 	if (err)
-		warning("Could not parse multicast config from file");
+		warning("Could not parse multicast config from file\n");
 
 	return err;
 }

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -855,7 +855,12 @@ int mcreceiver_alloc(struct sa *addr, uint8_t prio)
 		goto out;
 	}
 
-	if (IN_MULTICAST(sa_in(&mcreceiver->addr))) {
+	if (IN_MULTICAST(sa_in(&mcreceiver->addr))
+#ifdef HAVE_INET6
+	    || IN6_IS_ADDR_MULTICAST(&mcreceiver->addr.u.in6.sin6_addr)) {
+#else
+	    ) {
+#endif
 		err = udp_multicast_join((struct udp_sock *)
 			mcreceiver->rtp, &mcreceiver->addr);
 		if (err) {


### PR DESCRIPTION
`receiver.c` had a check for `IN_MULTICAST` which only works for IPv4 multicast addresses. Now, it also checks for IPv6 multicast addresses.