### PR TITLE
update to enum bevent_ev

### DIFF
--- a/modules/autotest/autotest.c
+++ b/modules/autotest/autotest.c
@@ -93,7 +93,7 @@ static void dial(void *arg)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua   *ua   = bevent_get_ua(event);
 	struct call *call = bevent_get_call(event);
@@ -102,23 +102,23 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	(void) arg;
 
 	info("autotest: [ ua=%s call=%s ] event: %s (%s)\n",
-	      account_aor(acc), call_id(call), uag_event_str(ev), txt);
+	      account_aor(acc), call_id(call), bevent_str(ev), txt);
 
 	switch (ev) {
 
-	case UA_EVENT_CALL_INCOMING:
-	case UA_EVENT_CALL_RINGING:
-	case UA_EVENT_CALL_PROGRESS:
-	case UA_EVENT_CALL_ANSWERED:
-	case UA_EVENT_CALL_ESTABLISHED:
-	case UA_EVENT_CALL_REMOTE_SDP:
-	case UA_EVENT_CALL_TRANSFER:
-	case UA_EVENT_CALL_TRANSFER_FAILED:
+	case BEVENT_CALL_INCOMING:
+	case BEVENT_CALL_RINGING:
+	case BEVENT_CALL_PROGRESS:
+	case BEVENT_CALL_ANSWERED:
+	case BEVENT_CALL_ESTABLISHED:
+	case BEVENT_CALL_REMOTE_SDP:
+	case BEVENT_CALL_TRANSFER:
+	case BEVENT_CALL_TRANSFER_FAILED:
 		if (d.dt_hangup)
 			tmr_start(&d.tmr_hangup, d.dt_hangup, hangup, NULL);
 		break;
 
-	case UA_EVENT_CALL_CLOSED:
+	case BEVENT_CALL_CLOSED:
 		if (d.dt_dial)
 			tmr_start(&d.tmr_dial, d.dt_dial, dial, NULL);
 		break;

--- a/modules/b2bua/b2bua.c
+++ b/modules/b2bua/b2bua.c
@@ -132,7 +132,7 @@ static int new_session(struct call *call)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct call *call = bevent_get_call(event);
 	int err;
@@ -140,7 +140,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 	switch (ev) {
 
-	case UA_EVENT_CALL_INCOMING:
+	case BEVENT_CALL_INCOMING:
 		debug("b2bua: CALL_INCOMING: peer=%s  -->  local=%s\n",
 		      call_peeruri(call), call_localuri(call));
 

--- a/modules/ebuacip/ebuacip.c
+++ b/modules/ebuacip/ebuacip.c
@@ -131,7 +131,7 @@ static bool ebuacip_handler(const char *name, const char *value, void *arg)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct audio *au;
 	struct ua   *ua   = bevent_get_ua(event);
@@ -142,17 +142,17 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 #if 1
 	debug(".... ebuacip: [ ua=%s call=%s ] event: %s (%s)\n",
 	      account_aor(ua_account(ua)), call_id(call),
-	      uag_event_str(ev), txt);
+	      bevent_str(ev), txt);
 #endif
 
 	switch (ev) {
 
-	case UA_EVENT_CALL_LOCAL_SDP:
+	case BEVENT_CALL_LOCAL_SDP:
 		if (0 == str_casecmp(txt, "offer"))
 			set_ebuacip_params(call_audio(call));
 		break;
 
-	case UA_EVENT_CALL_REMOTE_SDP:
+	case BEVENT_CALL_REMOTE_SDP:
 		au = call_audio(call);
 		sdp_media_rattr_apply(stream_sdpmedia(audio_strm(au)),
 				      "ebuacip", ebuacip_handler, au);

--- a/modules/intercom/events.c
+++ b/modules/intercom/events.c
@@ -17,7 +17,7 @@ static int reject_call(struct call *call, uint16_t scode, const char *reason)
 {
 	call_hangup(call, scode, reason);
 
-	bevent_call_emit(UA_EVENT_CALL_CLOSED, call, reason);
+	bevent_call_emit(BEVENT_CALL_CLOSED, call, reason);
 	return mem_deref_later(call);
 }
 
@@ -311,7 +311,7 @@ static int established_handler(const struct pl *name,
 }
 
 
-void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	const struct list *hdrs;
 	struct ua   *ua   = bevent_get_ua(event);
@@ -320,37 +320,37 @@ void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 	if (call) {
 		hdrs = call_get_custom_hdrs(call);
-		if (ev != UA_EVENT_CALL_DTMF_START &&
-		    ev != UA_EVENT_CALL_DTMF_END) {
+		if (ev != BEVENT_CALL_DTMF_START &&
+		    ev != BEVENT_CALL_DTMF_END) {
 			(void)custom_hdrs_apply(hdrs, check_hidden, event);
 		}
 	}
 
 	switch (ev) {
 
-	case UA_EVENT_CREATE:
+	case BEVENT_CREATE:
 		ua_add_xhdr_filter(ua, "Subject");
 		break;
 
-	case UA_EVENT_CALL_INCOMING:
+	case BEVENT_CALL_INCOMING:
 
 		(void)custom_hdrs_apply(hdrs, incoming_handler, call);
 		break;
 
-	case UA_EVENT_CALL_LOCAL_SDP:
+	case BEVENT_CALL_LOCAL_SDP:
 		if (call_state(call) != CALL_STATE_OUTGOING)
 			break;
 
 		(void)custom_hdrs_apply(hdrs, outgoing_handler, call);
 		break;
 
-	case UA_EVENT_CALL_ESTABLISHED:
+	case BEVENT_CALL_ESTABLISHED:
 
 		(void)custom_hdrs_apply(hdrs, established_handler, call);
 		break;
 
 
-	case UA_EVENT_CALL_CLOSED:
+	case BEVENT_CALL_CLOSED:
 		call_hidden_close(call);
 
 		break;

--- a/modules/intercom/intercom.h
+++ b/modules/intercom/intercom.h
@@ -5,7 +5,7 @@
  */
 
 
-void event_handler(enum ua_event ev, struct bevent *event, void *arg);
+void event_handler(enum bevent_ev ev, struct bevent *event, void *arg);
 
 int mem_deref_later(void *arg);
 struct iccustom *iccustom_find(const struct pl *val);

--- a/modules/kaoptions/kaoptions.c
+++ b/modules/kaoptions/kaoptions.c
@@ -209,19 +209,19 @@ static int kaoptions_stop(struct ua *ua)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	(void) arg;
 
 	switch (ev) {
-		case UA_EVENT_REGISTER_OK:
+		case BEVENT_REGISTER_OK:
 				kaoptions_alloc(ua);
 			break;
-		case UA_EVENT_REGISTER_FAIL:
+		case BEVENT_REGISTER_FAIL:
 				kaoptions_stop(ua);
 			break;
-		case UA_EVENT_UNREGISTERING:
+		case BEVENT_UNREGISTERING:
 				kaoptions_stop(ua);
 			break;
 

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -725,14 +725,14 @@ static const struct cmd cmdv[] = {
 };
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	(void)arg;
 	const struct sip_msg *msg  = bevent_get_msg(event);
 
 	switch (ev) {
 
-	case UA_EVENT_SIPSESS_CONN:
+	case BEVENT_SIPSESS_CONN:
 		if (mc.dnd) {
 			(void)sip_treply(NULL, uag_sip(), msg, 480,
 					 "Temporarily Unavailable");

--- a/modules/parcall/parcall.c
+++ b/modules/parcall/parcall.c
@@ -184,7 +184,7 @@ static bool parcall_debug(struct le *le, void *arg)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct le *le;
 	struct call *call = bevent_get_call(event);
@@ -192,7 +192,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	(void)arg;
 
 	switch (ev) {
-	case UA_EVENT_CALL_ESTABLISHED:
+	case BEVENT_CALL_ESTABLISHED:
 	{
 		le = hash_lookup(d.parcalls, hash_fast_str(call_id(call)),
 				 parcall_first, NULL);
@@ -203,7 +203,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	}
 
 	break;
-	case UA_EVENT_CALL_CLOSED:
+	case BEVENT_CALL_CLOSED:
 	{
 		le = hash_lookup(d.parcalls, hash_fast_str(call_id(call)),
 				 parcall_first, NULL);

--- a/modules/qualify/qualify.c
+++ b/modules/qualify/qualify.c
@@ -25,9 +25,9 @@
  * qual_int is greater than qual_to, and the call is incoming. As soon as
  * the call is established or closed, sending of OPTIONS is stopped.
  * If no response to an OPTIONS request is received within the specified
- * timeout, a UA_EVENT_MODULE with "peer offline" is triggered.
+ * timeout, a BEVENT_MODULE with "peer offline" is triggered.
  * In this case, the sending of OPTIONS still continues and if a subsequent
- * OPTIONS is answered, a UA_EVENT_MODULE with "peer online" is triggered.
+ * OPTIONS is answered, a BEVENT_MODULE with "peer online" is triggered.
  *
  * Example:
  * <sip:A@sip.example.com>;extra=qual_int=5,qual_to=2
@@ -241,7 +241,7 @@ static void qualle_stop_tmrs(struct qualle *qualle)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua   *ua   = bevent_get_ua(event);
 	struct call *call = bevent_get_call(event);
@@ -250,11 +250,11 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	(void) arg;
 
 	switch (ev) {
-		case UA_EVENT_CALL_INCOMING:
+		case BEVENT_CALL_INCOMING:
 			(void)call_start_qualify(call, acc, NULL);
 			break;
 
-		case UA_EVENT_CALL_ESTABLISHED:
+		case BEVENT_CALL_ESTABLISHED:
 			if (call_is_outgoing(call))
 			    break;
 
@@ -262,7 +262,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 			qualle_stop_tmrs(qualle);
 			break;
 
-		case UA_EVENT_CALL_CLOSED:
+		case BEVENT_CALL_CLOSED:
 			qualle = call_get_qualle(call);
 			qualle_stop_tmrs(qualle);
 

--- a/modules/redirect/redirect.c
+++ b/modules/redirect/redirect.c
@@ -28,7 +28,7 @@
  * ------
  *
  * The redirect module MUST be loaded before module menu because it stops the
- * UA_EVENT_SIPSESS_CONN event for an incoming SIP INVITE if a redirect is set
+ * BEVENT_SIPSESS_CONN event for an incoming SIP INVITE if a redirect is set
  * by the user. Whereas module menu would accept the SIP INVITE.
  *
  * ```
@@ -151,7 +151,7 @@ static int expires_alloc(char **bufp, uint32_t expires)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct le *le;
 	const struct sip_msg *msg = bevent_get_msg(event);
@@ -160,7 +160,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	(void)arg;
 
 	switch (ev) {
-	case UA_EVENT_SIPSESS_CONN:
+	case BEVENT_SIPSESS_CONN:
 	{
 		le = list_apply(&d.redirs, true, redirect_search, ua);
 		if (!le)


### PR DESCRIPTION
The `enum ua_event` was rename to `enum bevent_ev` in https://github.com/baresip/baresip/pull/3445.
