### PR TITLE
Multicast sender gong

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -174,31 +174,54 @@ static int cmd_mcsend(struct re_printf *pf, void *arg)
 {
 	int err = 0;
 	const struct cmd_arg *carg = arg;
-	struct pl pladdr, plcodec;
+	struct pl pladdr = PL_INIT;
+	struct pl plcodec = PL_INIT;
+	struct pl gong = PL_INIT;
 	struct sa addr;
 	struct aucodec *codec = NULL;
 
+	const char *usage = "usage: /mcsend addr=<IP>:<PORT> codec=<CODEC> "
+			    "optional(gong=<PATH>)\n";
+
 	err = re_regex(carg->prm, str_len(carg->prm),
-		"addr=[^ ]* codec=[^ ]*", &pladdr, &plcodec);
-	if (err)
-		goto out;
+		       "addr=[^ ]+ codec=[^ ]+ gong=[^ ]+",
+		       &pladdr, &plcodec, &gong);
+	if (err) {
+		err = re_regex(carg->prm, str_len(carg->prm),
+			       "addr=[^ ]+ codec=[^ ]+",
+			       &pladdr, &plcodec);
+			if (err) {
+				re_hprintf(pf, usage);
+				goto out;
+			}
+	}
 
 	err = decode_addr(&pladdr, &addr);
-	err |= decode_codec(&plcodec, &codec);
-	if (err)
+	if (err) {
+		re_hprintf(pf, "provided address not valid (%m)\n", err);
 		goto out;
+	}
+
+	err = decode_codec(&plcodec, &codec);
+	if (err) {
+		re_hprintf(pf, "provided codec not supported by baresip "
+			   "(%m)\n", err);
+		goto out;
+	}
 
 	err = check_rtp_pt(codec);
-	if (err)
+	if (err) {
+		re_hprintf(pf, "provided codec not supported by multicast "
+			   "(%m)\n", err);
 		goto out;
+	}
 
-	err = mcsender_alloc(&addr, codec);
+	err = mcsender_alloc(&addr, codec, &gong);
+	if (err)
+		re_hprintf(pf, "multicast sender allocation failed (%m)\n",
+			   err);
 
   out:
-	if (err)
-		re_hprintf(pf,
-			"usage: /mcsend addr=<IP>:<PORT> codec=<CODEC>\n");
-
 	return err;
 }
 

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -27,8 +27,10 @@ void multicast_set_dnd(bool v);
 /* Sender */
 typedef int (mcsender_send_h)(size_t ext_len, bool marker, uint32_t rtp_ts,
 	struct mbuf *mb, void *arg);
+typedef void (mcsender_eof_h)(void *arg);
 
-int  mcsender_alloc(struct sa *addr, const struct aucodec *codec);
+int  mcsender_alloc(struct sa *addr, const struct aucodec *codec,
+	struct pl *gong);
 void mcsender_stopall(void);
 void mcsender_stop(struct sa *addr);
 void mcsender_enable(bool enable);
@@ -62,7 +64,8 @@ void mcplayer_terminate(void);
 /* Source <exchangable source> */
 struct mcsource;
 int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
-	mcsender_send_h *sendh, void *arg);
+		   const struct pl *gong, mcsender_send_h *sendh,
+		   mcsender_eof_h *eofh, void *arg);
 void mcsource_stop(struct mcsource *src);
 
 int  mcsource_init(void);

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -509,13 +509,13 @@ static void rtp_process(const struct sa *src, const struct rtp_header *hdr,
 }
 
 
-static int pt_to_srate(int pt)
+static int pt_to_crate(int pt)
 {
 	switch (pt) {
 
 	case 0:  return 8000;   /* PCMU */
 	case 8:  return 8000;   /* PCMA */
-	case 9:  return 16000;  /* G722 */
+	case 9:  return 8000;   /* G722 due to an error in RFC */
 
 	default: return 0;
 	}
@@ -539,7 +539,7 @@ static void rtp_receive(const struct sa *src, const struct rtp_header *hdr,
 		rx->ssrc = hdr->ssrc;
 		rx->ssrc_set = true;
 		tmr_start(&rx->tmr_decode, 0, decode_tmr, rx);
-		jbuf_set_srate(rx->jbuf, pt_to_srate(hdr->pt));
+		jbuf_set_srate(rx->jbuf, pt_to_crate(hdr->pt));
 	}
 	else if (hdr->ssrc != ssrc0) {
 		debug("multicast receiver: SSRC changed 0x%x -> 0x%x"
@@ -552,7 +552,7 @@ static void rtp_receive(const struct sa *src, const struct rtp_header *hdr,
 	}
 
 	struct rtp_header hdrdup = *hdr;
-	hdrdup.ts_arrive = tmr_jiffies() * pt_to_srate(hdr->pt) / 1000;
+	hdrdup.ts_arrive = tmr_jiffies() * pt_to_crate(hdr->pt) / 1000;
 	rtp_process(src, &hdrdup, mb, arg);
 }
 

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -201,6 +201,7 @@ void mcsender_enable(bool enable)
 void mcsender_stopall(void)
 {
 	list_flush(&mcsenderl);
+	multicast_set_dnd(false);
 }
 
 
@@ -223,6 +224,9 @@ void mcsender_stop(struct sa *addr)
 	mcsender = le->data;
 	list_unlink(&mcsender->le);
 	mem_deref(mcsender);
+
+	if (list_count(&mcsenderl) == 0)
+		multicast_set_dnd(false);
 }
 
 
@@ -294,6 +298,7 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
 
 	mcsender->eofmax++;
 	list_append(&mcsenderl, &mcsender->le, mcsender);
+	multicast_set_dnd(true);
 
  out:
 	if (err)

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -101,6 +101,19 @@ static int mcsender_send_handler(size_t ext_len, bool marker,
 
 
 /**
+ * Gong EOF handler
+ *
+ * @param arg  Handler argument
+ */
+static void mcsender_gong_eof_handler(void *arg) {
+	struct mcsender *mcs = arg;
+
+	module_event("multicast", "sender gong eof", NULL, NULL,
+		     "addr=%J codec=%s", &mcs->addr, mcs->ac->name);
+}
+
+
+/**
  * Enable / Disable all existing sender
  *
  * @param enable
@@ -153,25 +166,30 @@ void mcsender_stop(struct sa *addr)
  *
  * @param addr  Destination address
  * @param codec Used audio codec
+ * @param gong  Optional absolute audio path
  *
  * @return 0 if success, otherwise errorcode
  */
-int mcsender_alloc(struct sa *addr, const struct aucodec *codec)
+int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
+		   struct pl *gong)
 {
-	int err = 0;
 	struct mcsender *mcsender = NULL;
 	uint8_t ttl = multicast_ttl();
+	int err = 0;
 
 	if (!addr || !codec)
 		return EINVAL;
 
-	if (list_apply(&mcsenderl, true, mcsender_addr_cmp, addr))
-		return EADDRINUSE;
-
+	if (list_apply(&mcsenderl, true, mcsender_addr_cmp, addr)) {
+		err = EADDRINUSE;
+		goto out;
+	}
 
 	mcsender = mem_zalloc(sizeof(*mcsender), mcsender_destructor);
-	if (!mcsender)
-		return ENOMEM;
+	if (!mcsender) {
+		err = ENOMEM;
+		goto out;
+	}
 
 	sa_cpy(&mcsender->addr, addr);
 	mcsender->ac = codec;
@@ -189,8 +207,11 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec)
 			IP_MULTICAST_TTL, &ttl, sizeof(ttl));
 	}
 
-	err = mcsource_start(&mcsender->src, mcsender->ac,
-		mcsender_send_handler, mcsender);
+	err = mcsource_start(&mcsender->src, mcsender->ac, gong,
+			     mcsender_send_handler, mcsender_gong_eof_handler,
+			     mcsender);
+	if (err)
+		goto out;
 
 	list_append(&mcsenderl, &mcsender->le, mcsender);
 

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -105,19 +105,27 @@ static int mcsender_send_handler(size_t ext_len, bool marker,
 	return err;
 }
 
+/**
+ * Generic Gong EOF handler
+ *
+ * @param mcs multicast sender struct
+ */
+static void mcsender_gong_eof_handler(struct mcsender *mcs) {
+	if (re_atomic_acq_add(&mcs->gong_eof, 1) == (mcs->eofmax - 1)) {
+		module_event("multicast", "sender gong eof", NULL, NULL,
+			"addr=%J codec=%s", &mcs->addr, mcs->ac->name);
+	}
+}
 
 /**
  * Gong EOF handler (multicast source)
  *
  * @param arg  Handler argument
  */
-static void mcsender_gong_eof_handler(void *arg) {
+static void mcsender_gong_stream_eof_handler(void *arg) {
 	struct mcsender *mcs = arg;
 
-	if (re_atomic_acq_add(&mcs->gong_eof, 1) == (mcs->eofmax - 1)) {
-		module_event("multicast", "sender gong eof", NULL, NULL,
-			"addr=%J codec=%s", &mcs->addr, mcs->ac->name);
-	}
+	mcsender_gong_eof_handler(mcs);
 }
 
 
@@ -132,10 +140,7 @@ static void mcsender_gong_play_end_handler(struct play *play, void *arg)
 	struct mcsender *mcs = arg;
 	(void) play;
 
-	if (re_atomic_acq_add(&mcs->gong_eof, 1) == (mcs->eofmax - 1)) {
-		module_event("multicast", "sender gong eof", NULL, NULL,
-			"addr=%J codec=%s", &mcs->addr, mcs->ac->name);
-	}
+	mcsender_gong_eof_handler(mcs);
 }
 
 
@@ -283,17 +288,21 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
 	}
 
 	err = mcsource_start(&mcsender->src, mcsender->ac, gong,
-			     mcsender_send_handler, mcsender_gong_eof_handler,
+			     mcsender_send_handler,
+			     mcsender_gong_stream_eof_handler,
 			     mcsender);
 	if (err)
 		goto out;
 
-	mcsender->eofmax++;
-	err = setup_local_gong(mcsender, gong);
-	if (err) {
-		warning ("mcsender: local gong playback failed. "
-			"cancel multicast (%m)\n", err);
-		goto out;
+	/* Only allow local gong playback for the very first multicast.*/
+	if (list_count(&mcsenderl) == 0) {
+		mcsender->eofmax++;
+		err = setup_local_gong(mcsender, gong);
+		if (err) {
+			warning ("mcsender: local gong playback failed. "
+				"cancel multicast (%m)\n", err);
+			goto out;
+		}
 	}
 
 	mcsender->eofmax++;

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -294,7 +294,7 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
 	if (err)
 		goto out;
 
-	/* Only allow local gong playback for the very first multicast.*/
+	/* Only allow local gong playback for the first sender.*/
 	if (list_count(&mcsenderl) == 0) {
 		mcsender->eofmax++;
 		err = setup_local_gong(mcsender, gong);

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -34,6 +34,10 @@ struct mcsender {
 	struct config_audio *cfg;
 	const struct aucodec *ac;
 
+	struct play *play;
+	RE_ATOMIC uint8_t gong_eof;
+	uint8_t eofmax;
+
 	struct mcsource *src;
 	bool enable;
 };
@@ -44,8 +48,10 @@ static void mcsender_destructor(void *arg)
 	struct mcsender *mcsender = arg;
 
 	mcsource_stop(mcsender->src);
-	mcsender->src = mem_deref(mcsender->src);
-	mcsender->rtp = mem_deref(mcsender->rtp);
+
+	mcsender->play   = mem_deref(mcsender->play);
+	mcsender->src    = mem_deref(mcsender->src);
+	mcsender->rtp    = mem_deref(mcsender->rtp);
 }
 
 
@@ -101,15 +107,74 @@ static int mcsender_send_handler(size_t ext_len, bool marker,
 
 
 /**
- * Gong EOF handler
+ * Gong EOF handler (multicast source)
  *
  * @param arg  Handler argument
  */
 static void mcsender_gong_eof_handler(void *arg) {
 	struct mcsender *mcs = arg;
 
-	module_event("multicast", "sender gong eof", NULL, NULL,
-		     "addr=%J codec=%s", &mcs->addr, mcs->ac->name);
+	if (re_atomic_acq_add(&mcs->gong_eof, 1) == (mcs->eofmax - 1)) {
+		module_event("multicast", "sender gong eof", NULL, NULL,
+			"addr=%J codec=%s", &mcs->addr, mcs->ac->name);
+	}
+}
+
+
+/**
+ * Gong EOF handler (baresip player)
+ *
+ * @param play
+ * @param arg
+ */
+static void mcsender_gong_play_end_handler(struct play *play, void *arg)
+{
+	struct mcsender *mcs = arg;
+	(void) play;
+
+	if (re_atomic_acq_add(&mcs->gong_eof, 1) == (mcs->eofmax - 1)) {
+		module_event("multicast", "sender gong eof", NULL, NULL,
+			"addr=%J codec=%s", &mcs->addr, mcs->ac->name);
+	}
+}
+
+
+/**
+ * Setup the player for local gong
+ *
+ * @param mcs  Multicast sender
+ * @param gong Path to gong file
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int setup_local_gong(struct mcsender *mcs, struct pl *gong)
+{
+	char *file = NULL;
+	int err = 0;
+
+	if (!mcs)
+		return EINVAL;
+
+	if (!pl_isset(gong))
+		return 0;
+
+	err = pl_strdup(&file, gong);
+	if (err)
+		return err;
+
+	/* TODO: make multicast gong playback module and device configurable */
+	err = play_file(&mcs->play, baresip_player(), file, 0,
+			mcs->cfg->alert_mod, mcs->cfg->alert_dev);
+	if (err) {
+		warning ("mcsender: play file (%m)\n", err);
+		goto out;
+	}
+
+	play_set_finish_handler(mcs->play, mcsender_gong_play_end_handler,
+				mcs);
+out:
+	mem_deref(file);
+	return err;
 }
 
 
@@ -194,13 +259,19 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
 	sa_cpy(&mcsender->addr, addr);
 	mcsender->ac = codec;
 	mcsender->enable = true;
+	mcsender->cfg = &conf_config()->audio;
+	mcsender->eofmax = 0;
+	re_atomic_rlx_set(&mcsender->gong_eof, 0);
 
 	err = rtp_open(&mcsender->rtp, sa_af(&mcsender->addr));
-	if (err)
+	if (err) {
+		warning ("mcsender: rtp socket creation failed (%m)", err);
 		goto out;
+	}
 
 	if (ttl > 1) {
 		struct udp_sock *sock;
+		debug ("mcsender: set RTP package TTL to %d\n", ttl);
 
 		sock = (struct udp_sock *) rtp_sock(mcsender->rtp);
 		udp_setsockopt(sock, IPPROTO_IP,
@@ -213,6 +284,15 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec,
 	if (err)
 		goto out;
 
+	mcsender->eofmax++;
+	err = setup_local_gong(mcsender, gong);
+	if (err) {
+		warning ("mcsender: local gong playback failed. "
+			"cancel multicast (%m)\n", err);
+		goto out;
+	}
+
+	mcsender->eofmax++;
 	list_append(&mcsenderl, &mcsender->le, mcsender);
 
  out:

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -159,6 +159,7 @@ static int send_aubuf(struct mcsource *src)
 {
 	struct auframe af;
 	size_t sampc = 0;
+	struct le *le;
 	int err = 0;
 
 	if (!re_atomic_rlx(&src->eof)) {
@@ -202,6 +203,16 @@ static int send_aubuf(struct mcsource *src)
 		}
 
 		auframe_update(&af, src->sampv_rs, sampc, af.timestamp);
+	}
+
+	for (le = src->filtl.head; le; le = le->next) {
+		struct aufilt_enc_st *st = le->data;
+		if (st->af && st->af->ench)
+			err |= st->af->ench(st, &af);
+	}
+
+	if (err) {
+		warning("mcsource: aufilter encode: (%m)\n", err);
 	}
 
 	return send_af(src, &af);
@@ -559,7 +570,7 @@ static int setup_aufilt(struct mcsource *src, struct list *aufiltl)
 			err = af->encupdh(&encst, &ctx, af, &prm, NULL);
 			if (err) {
 				warning ("mcsource: audio filter %s setup "
-					"faild (%m), continue with next\n",
+					"failed (%m)\n",
 					af->name, err);
 				continue;
 			}

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -570,8 +570,7 @@ static int setup_aufilt(struct mcsource *src, struct list *aufiltl)
 			err = af->encupdh(&encst, &ctx, af, &prm, NULL);
 			if (err) {
 				warning ("mcsource: audio filter %s setup "
-					"failed (%m)\n",
-					af->name, err);
+					"failed (%m)\n", af->name, err);
 				continue;
 			}
 

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -377,6 +377,7 @@ static int tx_thread(void *arg)
 		ts += PTIME;
 	}
 
+	debug("mcsource: leave tx_thread loop\n");
 	return 0;
 }
 

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -3,7 +3,6 @@
  *
  * Copyright (C) 2021 Commend.com - c.huber@commend.com
  */
-
 #include <re_atomic.h>
 #include <re.h>
 #include <rem.h>
@@ -24,39 +23,45 @@
  * Contains configuration of the audio source and buffer for the audio data
  */
 struct mcsource {
-	struct config_audio *cfg;
-	struct ausrc_st *ausrc;
-	struct ausrc_prm ausrc_prm;
-	const struct aucodec *ac;
-	struct auenc_state *enc;
-	enum aufmt src_fmt;
-	enum aufmt enc_fmt;
+	mtx_t lock;
 
-	void *sampv;
+	struct config_audio *cfg;
+
+	const struct aucodec *ac;
+	struct auenc_state   *enc;
+
+	char               *gong;
+	const struct ausrc *src_gong;
+	struct ausrc_st    *src_gong_st;
+	struct ausrc_prm    gong_prm;
+	RE_ATOMIC bool      eof;
+	mcsender_eof_h     *eofh;
+
+	const struct ausrc *src_mic;
+	struct ausrc_st    *src_mic_st;
+	struct ausrc_prm    mic_prm;
+	RE_ATOMIC bool      mic_muted;
+
 	struct aubuf *aubuf;
-	size_t aubuf_maxsz;
-	volatile bool aubuf_started;
-	struct auresamp resamp;
-	int16_t *sampv_rs;
+	void         *sampv;
+
+	struct auresamp  resamp;
+	void            *sampv_rs;
+
 	struct list filtl;
 
-	struct mbuf *mb;
-	uint32_t ptime;
-	uint64_t ts_ext;
-	uint32_t ts_base;
-	size_t psize;
-	bool marker;
-
-	char *module;
-	char *device;
-
+	struct mbuf     *rtp_mb;
+	bool             rtp_marker;
+	uint32_t         ts_ext;
+	uint32_t         ts_base;
 	mcsender_send_h *sendh;
-	void *arg;
 
 	struct {
 		thrd_t tid;
 		RE_ATOMIC bool run;
 	} thr;
+
+	void *arg;
 };
 
 
@@ -69,68 +74,60 @@ static void mcsource_destructor(void *arg)
 		thrd_join(src->thr.tid, NULL);
 	}
 
-	src->ausrc = mem_deref(src->ausrc);
-	src->aubuf = mem_deref(src->aubuf);
-	list_flush(&src->filtl);
+	src->enc = mem_deref(src->enc);
 
-	src->enc      = mem_deref(src->enc);
-	src->mb       = mem_deref(src->mb);
-	src->sampv    = mem_deref(src->sampv);
+	src->gong = mem_deref(src->gong);
+	src->src_gong_st = mem_deref(src->src_gong_st);
+	src->src_mic_st = mem_deref(src->src_mic_st);
+
+	src->aubuf = mem_deref(src->aubuf);
+	src->sampv = mem_deref(src->sampv);
 	src->sampv_rs = mem_deref(src->sampv_rs);
 
-	src->module   = mem_deref(src->module);
-	src->device   = mem_deref(src->device);
+	src->rtp_mb = mem_deref(src->rtp_mb);
+	list_flush(&src->filtl);
+	mtx_destroy(&src->lock);
 }
 
 
 /**
- * Encode and send audio data via multicast send handler of src
+ * Send auframe data via network (RTP)
  *
- * @note This function has REAL-TIME properties
+ * @param src Multicast source
+ * @param af  Audio frame
  *
- * @param src   Multicast source object
- * @param sampv Samplebuffer
- * @param sampc Samplecounter
+ * @return 0 if success, otherwise errorcode
  */
-static void encode_rtp_send(struct mcsource *src, uint16_t *sampv,
-	size_t sampc)
+static int send_af(struct mcsource *src, struct auframe *af)
 {
-	size_t frame_size;
-	size_t sampc_rtp;
-	size_t len;
-
-	size_t ext_len = 0;
+	size_t sampc_rtp = 0, len = 0, frame_size = 0;
 	uint32_t ts_delta = 0;
 	int err = 0;
 
 	if (!src->ac || !src->ac->ench)
-		return;
+		return EINVAL;
 
-	src->mb->pos = src->mb->end = STREAM_PRESZ;
-
-	len = mbuf_get_space(src->mb);
-	err = src->ac->ench(src->enc, &src->marker, mbuf_buf(src->mb), &len,
-		src->enc_fmt, sampv, sampc);
-
+	src->rtp_mb->pos = src->rtp_mb->end = STREAM_PRESZ;
+	len = mbuf_get_space(src->rtp_mb);
+	/* TODO: Add AUFMT check and auconv if necessary */
+	err = src->ac->ench(src->enc, &src->rtp_marker, mbuf_buf(src->rtp_mb),
+			    &len, af->fmt, af->sampv, af->sampc);
 	if ((err & 0xffff0000) == 0x00010000) {
 		ts_delta = err & 0xffff;
-		sampc = 0;
+		af->sampc = 0;
 	}
 	else if (err) {
-		warning ("multicast send: &s encode error: &d samples (%m)\n",
-			src->ac->name, sampc, err);
+		warning ("mcsource: audio encoding failed (%m)\n", err);
 		goto out;
 	}
 
-	src->mb->pos = STREAM_PRESZ;
-	src->mb->end = STREAM_PRESZ + ext_len + len;
-
-	if (mbuf_get_left(src->mb)) {
+	src->rtp_mb->pos = STREAM_PRESZ;
+	src->rtp_mb->end = STREAM_PRESZ + len;
+	if (mbuf_get_left(src->rtp_mb)) {
 		uint32_t rtp_ts = src->ts_ext & 0xffffffff;
-
 		if (len) {
-			err = src->sendh(ext_len, src->marker,
-				rtp_ts, src->mb, src->arg);
+			err = src->sendh(0, src->rtp_marker, rtp_ts,
+					 src->rtp_mb, src->arg);
 			if (err)
 				goto out;
 		}
@@ -139,167 +136,212 @@ static void encode_rtp_send(struct mcsource *src, uint16_t *sampv,
 			src->ts_ext += ts_delta;
 			goto out;
 		}
+
 	}
 
-	sampc_rtp = sampc * src->ac->crate / src->ac->srate;
+	sampc_rtp = af->sampc * src->ac->crate / src->ac->srate;
 	frame_size = sampc_rtp / src->ac->ch;
 	src->ts_ext += (uint32_t) frame_size;
-
-  out:
-	src->marker = false;
+out:
+	src->rtp_marker = false;
+	return err;
 }
 
 
 /**
- * Poll timed read from audio buffer
+ * Pull frames from aubuf & processing
  *
- * @note This function has REAL-TIME properties
+ * @param src  Multicast source
  *
- * @param src Multicast source object
+ * @return 0 if success, otherwise errorcode
  */
-static void poll_aubuf_tx(struct mcsource *src)
+static int poll_aubuf_tx(struct mcsource *src)
 {
 	struct auframe af;
-	int16_t *sampv = src->sampv;
-	size_t sampc;
-	size_t sz;
-	size_t num_bytes;
-	struct le *le;
-	uint32_t srate;
-	uint8_t ch;
+	size_t sampc = 0;
 	int err = 0;
 
-	sz = aufmt_sample_size(src->src_fmt);
-	if (!sz)
-		return;
-
-	num_bytes = src->psize;
-	sampc = num_bytes / sz;
-
-	if (src->src_fmt == AUFMT_S16LE) {
-		aubuf_read(src->aubuf, (uint8_t *)sampv, num_bytes);
-	}
-	else if (src->enc_fmt == AUFMT_S16LE) {
-		void *tmp_sampv = NULL;
-
-		tmp_sampv = mem_zalloc(num_bytes, NULL);
-		if (!tmp_sampv)
-			return;
-
-		aubuf_read(src->aubuf, tmp_sampv, num_bytes);
-		auconv_to_s16(sampv, src->src_fmt, tmp_sampv, sampc);
-		mem_deref(tmp_sampv);
+	if (!re_atomic_rlx(&src->eof)) {
+		sampc = (src->gong_prm.srate * src->gong_prm.ch * PTIME) /
+			1000;
+		auframe_init(&af, AUFMT_S16LE, src->sampv, sampc,
+			     src->gong_prm.srate, src->gong_prm.ch);
 	}
 	else {
-		warning("multicast send: invalid sample formats (%s -> %s)\n",
-			aufmt_name(src->src_fmt),
-			aufmt_name(src->enc_fmt));
+		sampc = (src->mic_prm.srate * src->mic_prm.ch * PTIME) / 1000;
+		auframe_init(&af, AUFMT_S16LE, src->sampv, sampc,
+			     src->mic_prm.srate, src->mic_prm.ch);
 	}
 
-	if (src->resamp.resample) {
-		size_t sampc_rs = AUDIO_SAMPSZ;
+	aubuf_read_auframe(src->aubuf, &af);
+	if (af.srate != src->ac->srate) {
+		if (af.srate != src->resamp.irate) {
+			debug ("mcsource: resampling resetup needed "
+				"(%u:%u -> %u:%u)\n",
+				af.srate, af.ch, src->ac->srate, src->ac->ch);
+			auresamp_init(&src->resamp);
+			err = auresamp_setup(&src->resamp, af.srate, af.ch,
+					     src->ac->srate, src->ac->ch);
+			if (err) {
+				warning ("mcsource: resampler setup failed "
+					"(%m)\n", err);
+				return err;
+			}
+		}
 
-		if (src->enc_fmt != AUFMT_S16LE) {
-			warning("multicast send: skipping resampler due to"
-				" incompatible format (%s)\n",
-				aufmt_name(src->enc_fmt));
+		if (af.srate < src->ac->srate)
+			sampc = (src->resamp.orate * src->resamp.och
+				* PTIME) / 1000;
+
+		err = auresamp(&src->resamp, src->sampv_rs, &sampc,
+			       af.sampv, af.sampc);
+		if (err) {
+			warning ("mcsource: resampling failed (%m)\n", err);
+			return err;
+		}
+
+		auframe_update(&af, src->sampv_rs, sampc, af.timestamp);
+	}
+
+	return send_af(src, &af);
+}
+
+
+/**
+ * Audio source error handler (file)
+ *
+ * @param err Error code
+ * @param str Error reason
+ * @param arg Handler argument
+ */
+static void src_mic_err_handler(int err, const char *str, void *arg)
+{
+	struct mcsource *src = arg;
+	(void) src;
+	(void) str;
+	(void) err;
+}
+
+
+/**
+ * Audio source read handler (mic)
+ *
+ * @param af  Audio frame
+ * @param arg Handler argument
+ */
+static void src_mic_read_handler(struct auframe *af, void *arg)
+{
+	struct mcsource *src = arg;
+	int err = 0;
+
+	mtx_lock(&src->lock);
+	if (re_atomic_rlx(&src->mic_muted)) {
+		mtx_unlock(&src->lock);
+		return;
+	}
+
+	err = aubuf_write_auframe(src->aubuf, af);
+	if (err)
+		warning ("mcsource: mic aubuf_write (%m)\n", err);
+
+	mtx_unlock(&src->lock);
+}
+
+
+/**
+ * Audio source error handler (gong)
+ *
+ * @param err Error code
+ * @param str Error reason
+ * @param arg Handler argument
+ */
+static void src_gong_err_handler(int err, const char *str, void *arg)
+{
+	struct mcsource *src = arg;
+	size_t sample_bytes = AUDIO_SAMPSZ *
+			      aufmt_sample_size(src->mic_prm.fmt);
+	int ierr = 0;
+
+	mtx_lock(&src->lock);
+	if (err == 0) {
+		info ("mcsource: src_gong reached EOF: %s\n", str);
+		re_atomic_rlx_set(&src->eof, true);
+
+		/*
+		   TODO:
+		   aubuf_flush is not able to clear out the full memory pool.
+		   the writing threads
+		   (src_gong_read_handler & src_mic_read_handler) will output
+		   list: insert_after: le linked to 0x0000deadbeef
+		   The aubuf in question is externaly mutex locked whereever
+		   it gets accessed. (read, write & flush)
+
+		   aubuf_flush(src->aubuf);
+
+		   Workaround: Free old buffer and allocate a new buffer
+		*/
+		src->aubuf = mem_deref(src->aubuf);
+		ierr = aubuf_alloc(&src->aubuf, sample_bytes,
+				   sample_bytes * 30);
+		if (ierr) {
+			warning ("mcsource: realocation workaround (%m)\n",
+				 ierr);
+			mtx_unlock(&src->lock);
 			return;
 		}
 
-		err = auresamp(&src->resamp, src->sampv_rs, &sampc_rs,
-			src->sampv, sampc);
-			if (err)
-				return;
+		aubuf_set_mode(src->aubuf, AUBUF_FIXED);
+		aubuf_set_live(src->aubuf, true);
 
-		sampv = src->sampv_rs;
-		sampc = sampc_rs;
+		re_atomic_rlx_set(&src->mic_muted, false);
+		src->eofh(src->arg);
 	}
-
-	if (src->resamp.resample) {
-		srate = src->resamp.irate;
-		ch = src->resamp.ich;
-	}
-	else {
-		srate = src->ausrc_prm.srate;
-		ch = src->ausrc_prm.ch;
-	}
-
-	auframe_init(&af, src->enc_fmt, sampv, sampc, srate, ch);
-
-	/* process exactly one audio-frame in list order */
-	for (le = src->filtl.head; le; le = le->next) {
-		struct aufilt_enc_st * st = le->data;
-
-		if (st->af && st->af->ench)
-			err |= st->af->ench(st, &af);
-	}
-
-	if (err)
-		warning("multicast source: aufilter encode (%m)\n", err);
-
-	encode_rtp_send(src, af.sampv, af.sampc);
+	mtx_unlock(&src->lock);
 }
 
 
 /**
- * Audio source error handler
- *
- * @param err Error code
- * @param str Error string
- * @param arg Multicast source object
- */
-static void ausrc_error_handler(int err, const char *str, void *arg)
-{
-	(void) err;
-	(void) str;
-	(void) arg;
-}
-
-
-/**
- * Audio source read handler
- *
- * @note This function has REAL-TIME properties
+ * Audio source read handler (file)
  *
  * @param af  Audio frame
- * @param arg Multicast source object
+ * @param arg Handler argument
  */
-static void ausrc_read_handler(struct auframe *af, void *arg)
+static void src_gong_read_handler(struct auframe *af, void *arg)
 {
 	struct mcsource *src = arg;
-	size_t num_bytes = auframe_size(af);
+	int err = 0;
 
-	if (src->src_fmt != af->fmt) {
-		warning ("multicast source: ausrc format mismatch: "
-			"expected=%d(%s), actual=%d(%s)\n",
-			src->src_fmt, aufmt_name(src->src_fmt),
-			af->fmt, aufmt_name(af->fmt));
+	mtx_lock(&src->lock);
+	if (re_atomic_rlx(&src->eof)) {
+		mtx_unlock(&src->lock);
 		return;
 	}
 
-	(void) aubuf_write(src->aubuf, af->sampv, num_bytes);
-	src->aubuf_started = true;
+	err = aubuf_write_auframe(src->aubuf, af);
+	if (err)
+		warning ("mcsource: gong aubuf_write (%m)\n", err);
+
+	mtx_unlock(&src->lock);
 }
 
 
 /**
- * Standalone transmitter thread function
+ * Threaded transmission loop
  *
- * @param arg Multicast source object
+ * @param arg  Transmission argument
  *
- * @return NULL
+ * @return 0 if success, otherwise errorcode
  */
 static int tx_thread(void *arg)
 {
 	struct mcsource *src = arg;
+	size_t sz = (src->ac->srate * src->ac->ch * PTIME / 1000) *
+		     aufmt_sample_size(src->mic_prm.fmt);
 	uint64_t ts = 0;
 
 	while (re_atomic_rlx(&src->thr.run)) {
 		uint64_t now;
 		sys_msleep(4);
-
-		if (!src->aubuf_started)
-			continue;
 
 		if (!re_atomic_rlx(&src->thr.run))
 			break;
@@ -307,14 +349,15 @@ static int tx_thread(void *arg)
 		now = tmr_jiffies();
 		if (!ts)
 			ts = now;
-
 		if (ts > now)
 			continue;
 
-		if (aubuf_cur_size(src->aubuf) >= src->psize)
+		mtx_lock(&src->lock);
+		if (aubuf_cur_size(src->aubuf) >= sz)
 			poll_aubuf_tx(src);
+		mtx_unlock(&src->lock);
 
-		ts += src->ptime;
+		ts += PTIME;
 	}
 
 	return 0;
@@ -322,91 +365,25 @@ static int tx_thread(void *arg)
 
 
 /**
- * Start audio source
+ * Set the up aucodec object
  *
- * @param src Multicast source object
+ * @param src  Multicast source object
+ * @param ac   Audio codec object
  *
  * @return 0 if success, otherwise errorcode
  */
-static int start_source(struct mcsource *src)
+static int setup_aucodec(struct mcsource *src, const struct aucodec *ac)
 {
 	int err = 0;
-	uint32_t srate_dsp;
-	uint32_t channels_dsp;
-	bool resamp = false;
 
-	if (!src)
+	if (!src || !ac)
 		return EINVAL;
 
-	srate_dsp = src->ac->srate;
-	channels_dsp = src->ac->ch;
-
-	if (src->cfg->srate_src && src->cfg->srate_src != srate_dsp) {
-		resamp = true;
-		srate_dsp = src->cfg->srate_src;
-	}
-	if (src->cfg->channels_src && src->cfg->channels_src != channels_dsp) {
-		resamp = true;
-		channels_dsp = src->cfg->channels_src;
-	}
-
-	if (resamp && src->sampv_rs) {
-		src->sampv_rs = mem_zalloc(
-			AUDIO_SAMPSZ * sizeof(int16_t), NULL);
-		if (!src->sampv_rs)
-			return ENOMEM;
-
-		err = auresamp_setup(&src->resamp, srate_dsp, channels_dsp,
-			src->ac->srate, src->ac->ch);
-		if (err) {
-			warning ("multicast source: could not setup ausrc "
-				"resample (%m)\n", err);
-			return err;
-		}
-	}
-
-	if (!src->ausrc && ausrc_find(baresip_ausrcl(), NULL)) {
-		struct ausrc_prm prm;
-		size_t sz;
-
-		prm.srate = srate_dsp;
-		prm.ch = channels_dsp;
-		prm.ptime = src->ptime;
-		prm.fmt = src->src_fmt;
-
-		sz = aufmt_sample_size(src->src_fmt);
-		src->psize = sz * (prm.srate * prm.ch * prm.ptime / 1000);
-		src->aubuf_maxsz = src->psize * 30;
-		if (!src->aubuf) {
-			err = aubuf_alloc(&src->aubuf, src->psize,
-				src->aubuf_maxsz);
-			if (err)
-				return err;
-		}
-
-		err = ausrc_alloc(&src->ausrc, baresip_ausrcl(),
-			src->module, &prm, src->device,
-			ausrc_read_handler, ausrc_error_handler, src);
-		if (err) {
-			warning ("multicast source: start_source faild (%s-%s)"
-				" (%m)\n", src->module, src->device, err);
-			return err;
-		}
-
-		if (!re_atomic_rlx(&src->thr.run)) {
-			re_atomic_rlx_set(&src->thr.run, true);
-			err = thread_create_name(&src->thr.tid,
-						 "multicast", tx_thread, src);
-			if (err) {
-				re_atomic_rlx_set(
-						  &src->thr.run, false);
-				return err;
-			}
-		}
-
-		src->ausrc_prm = prm;
-		info ("multicast source: source started with sample format "
-			"%s\n", aufmt_name(src->src_fmt));
+	src->ac = ac;
+	if (src->ac->encupdh) {
+		struct auenc_param prm;
+		prm.bitrate = 0;
+		err = src->ac->encupdh(&src->enc, src->ac, &prm, NULL);
 	}
 
 	return err;
@@ -414,29 +391,161 @@ static int start_source(struct mcsource *src)
 
 
 /**
- * Setup all available audio filter for the encoder
+ * Set the up ausrc object for file playing on stream
  *
- * @param src     Multicast source object
- * @param aufiltl List of audio filter
+ * @param src  Multicast source object
+ * @param file Absolute file path
  *
  * @return 0 if success, otherwise errorcode
  */
-static int aufilt_setup(struct mcsource *src, struct list *aufiltl)
+static int setup_ausrc_gong(struct mcsource *src, const char *file)
+{
+	struct pl plopt;
+	char *opt = NULL;
+	int err = 0;
+
+	if (!src || !file)
+		return EINVAL;
+
+	if (!conf_get(conf_cur(), "file_ausrc", &plopt)) {
+		uint32_t srate = 16000;
+		uint32_t ch = 1;
+
+		conf_get_u32(conf_cur(), "file_srate", &srate);
+		conf_get_u32(conf_cur(), "file_channels", &ch);
+
+		src->gong_prm.fmt = AUFMT_S16LE;
+		src->gong_prm.srate = srate;
+		src->gong_prm.ch = ch;
+		src->gong_prm.ptime = PTIME;
+
+		err = pl_strdup(&opt, &plopt);
+		if (err)
+			goto out;
+
+		src->src_gong = ausrc_find(baresip_ausrcl(), opt);
+		if (!src->src_gong) {
+			err = ENOTSUP;
+			goto out;
+		}
+
+		err = src->src_gong->alloch(&src->src_gong_st, src->src_gong,
+					    &src->gong_prm, file,
+					    src_gong_read_handler,
+					    src_gong_err_handler, src);
+	}
+	else {
+		return EINVAL;
+	}
+
+out:
+	mem_deref(opt);
+	return err;
+}
+
+
+/**
+ * Set the up ausrc object for microphone
+ *
+ * @param src   Multicast source object
+ * @param ausrc Ausrc for microphone object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int setup_ausrc_mic(struct mcsource *src, const struct ausrc *ausrc)
+{
+	int err = 0;
+
+	if (!src || !src->cfg || !ausrc)
+		return EINVAL;
+
+	src->mic_prm.fmt   = src->cfg->src_fmt ?
+			     src->cfg->src_fmt : AUFMT_S16LE;
+	src->mic_prm.srate = src->cfg->srate_src ? src->cfg->srate_src : 16000;
+	src->mic_prm.ch    = src->cfg->channels_src ?
+			     src->cfg->channels_src : 2;
+	src->mic_prm.ptime = PTIME;
+
+	src->src_mic = ausrc;
+	if (!src->src_mic_st) {
+		err = src->src_mic->alloch(&src->src_mic_st, src->src_mic,
+					   &src->mic_prm, src->cfg->src_dev,
+					   src_mic_read_handler,
+					   src_mic_err_handler, src);
+	}
+
+	return err;
+}
+
+/**
+ * Allocate necessary buffers
+ *
+ * @param src Multicast source object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int setup_buffers(struct mcsource *src)
+{
+	size_t sample_bytes = AUDIO_SAMPSZ * aufmt_sample_size(AUFMT_S16LE);
+	int err = 0;
+
+	if (!src)
+		return EINVAL;
+
+	err = aubuf_alloc(&src->aubuf, sample_bytes, sample_bytes * 30);
+	if (err) {
+		warning ("mcsource: failed to allocate audio buffer (%m)\n",
+			 err);
+		goto out;
+	}
+
+	aubuf_set_mode(src->aubuf, AUBUF_FIXED);
+	if (src->src_gong)
+		aubuf_set_live(src->aubuf, false);
+
+	src->sampv = mem_zalloc(sample_bytes, NULL);
+	src->sampv_rs = mem_zalloc(sample_bytes, NULL);
+	if (!src->sampv || !src->sampv_rs) {
+		err = ENOMEM;
+		warning ("mcsource: failed to allocate sample buffers (%m)\n",
+			 err);
+		goto out;
+	}
+
+	src->rtp_mb = mbuf_alloc(STREAM_PRESZ + 4069);
+	if (!src->rtp_mb) {
+		err = ENOMEM;
+		warning ("mcsource: failed to allocate rtp package buffer "
+			 "(%m)\n",  err);
+	}
+out:
+	return err;
+}
+
+
+/**
+ * Set the up aufilt in applied order
+ *
+ * @param src     Multicast source
+ * @param aufiltl Audio filter list
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int setup_aufilt(struct mcsource *src, struct list *aufiltl)
 {
 	struct aufilt_prm prm;
 	struct le *le;
 	int err = 0;
 
-	if (!src->ac)
-		return 0;
+	if (!src || !src->ac)
+		return EINVAL;
 
-	if (!list_isempty(&src->filtl))
+	if (!aufiltl || list_isempty(aufiltl))
 		return 0;
 
 	prm.srate = src->ac->srate;
 	prm.ch = src->ac->ch;
-	prm.fmt = src->enc_fmt;
-
+	prm.fmt = src->mic_prm.fmt;
 	for (le = list_head(aufiltl); le; le = le->next) {
 		struct aufilt *af = le->data;
 		struct aufilt_enc_st *encst = NULL;
@@ -445,22 +554,42 @@ static int aufilt_setup(struct mcsource *src, struct list *aufiltl)
 		if (af->encupdh) {
 			err = af->encupdh(&encst, &ctx, af, &prm, NULL);
 			if (err) {
-				warning("multicast source: erro in encoder"
-					"autio-filter '%s' (%m)\n",
+				warning ("mcsource: audio filter %s setup "
+					"faild (%m), continue with next\n",
 					af->name, err);
+				continue;
 			}
-			else {
-				encst->af = af;
-				list_append(&src->filtl, &encst->le,
-					encst);
-			}
-		}
 
-		if (err) {
-			warning("multicast source: audio-filter '%s' "
-				"update failed (%m)\n", af->name, err);
-			break;
+			encst->af = af;
+			list_append(&src->filtl, &encst->le, encst);
 		}
+	}
+
+	return 0;
+}
+
+
+/**
+ * Startup the transmission.
+ *
+ * @param src  Multicast source
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int start_tx(struct mcsource *src)
+{
+	int err = 0;
+
+	if (!src)
+		return EINVAL;
+
+	re_atomic_rlx_set(&src->thr.run, true);
+	err = thread_create_name(&src->thr.tid, "mcsource",
+					tx_thread, src);
+	if (err) {
+		re_atomic_rlx_set(&src->thr.run, false);
+		warning ("mcsource: transmittion thread "
+				"startup (%m)\n", err);
 	}
 
 	return err;
@@ -472,76 +601,104 @@ static int aufilt_setup(struct mcsource *src, struct list *aufiltl)
  *
  * @param srcp  Multicast source ptr
  * @param ac    Audio codec
+ * @param gong  Absolute path to gong file
  * @param sendh Send handler ptr
+ * @param eofh  EOF handler ptr
  * @param arg   Send handler Argument
  *
  * @return 0 if success, otherwise errorcode
  */
 int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
-	mcsender_send_h *sendh, void *arg)
+		   const struct pl *gong, mcsender_send_h *sendh,
+		   mcsender_eof_h *eofh, void *arg)
 {
+	struct mcsource *mc_src = NULL;
 	int err = 0;
-	struct mcsource *src = NULL;
-	struct config_audio *cfg = &conf_config()->audio;
 
 	if (!srcp || !ac)
 		return EINVAL;
 
-	src = mem_zalloc(sizeof(*src), mcsource_destructor);
-	if (!src)
+	mc_src = mem_zalloc(sizeof(*mc_src), mcsource_destructor);
+	if (!mc_src)
 		return ENOMEM;
 
-	src->cfg = cfg;
-	src->sendh = sendh;
-	src->arg = arg;
-
-	src->src_fmt = cfg->src_fmt;
-	src->enc_fmt = cfg->enc_fmt;
-	src->mb = mbuf_alloc(STREAM_PRESZ + 4096);
-	src->sampv = mem_zalloc(
-		AUDIO_SAMPSZ * aufmt_sample_size(src->enc_fmt), NULL);
-	if (!src->mb || !src->sampv) {
+	err = mtx_init(&mc_src->lock, mtx_plain) != thrd_success;
+	if (err) {
 		err = ENOMEM;
 		goto out;
 	}
 
-	auresamp_init(&src->resamp);
-	src->ptime = PTIME;
-	src->ts_ext = src->ts_base = rand_u16();
-	src->marker = true;
+	mc_src->cfg = &conf_config()->audio;
 
-	err = str_dup(&src->module, cfg->src_mod);
-	err |= str_dup(&src->device, cfg->src_dev);
-	if (err)
+	debug ("mcsource: setting up audio encoder %s\n", ac->name);
+	err = setup_aucodec(mc_src, ac);
+	if (err) {
+		warning ("mcsource: codec setup failed (%m)\n", err);
 		goto out;
+	}
 
-	src->ac = ac;
-	if (src->ac->encupdh) {
-		struct auenc_param prm;
+	debug ("mcsource: setting up and allocation of buffers\n");
+	err = setup_buffers(mc_src);
+	if (err) {
+		warning("mcsource: failed to allocate necessary buffers "
+			"(%m)\n", err);
+		goto out;
+	}
 
-		prm.bitrate = 0;
+	mc_src->sendh = sendh;
+	mc_src->eofh = eofh;
+	mc_src->arg = arg;
+	mc_src->ts_ext = mc_src->ts_base = rand_u32();
 
-		err = src->ac->encupdh(&src->enc, src->ac, &prm, NULL);
+	debug ("mcsource: initialize resampler\n");
+	auresamp_init(&mc_src->resamp);
+
+	debug ("mcsource: setting up audio filter in applied order\n");
+	err = setup_aufilt(mc_src, baresip_aufiltl());
+	if (err) {
+		warning ("mcsource: audio filter setup failed (%m) \n", err);
+		goto out;
+	}
+
+	re_atomic_rlx_set(&mc_src->eof, true);
+	if (pl_isset(gong)) {
+		debug ("mcsource: setting up file source for pre-gong\n");
+		re_atomic_rlx_set(&mc_src->eof, false);
+		re_atomic_rlx_set(&mc_src->mic_muted, true);
+		err = pl_strdup(&mc_src->gong, gong);
 		if (err) {
-			warning ("multicast source: alloc encoder (%m)\n",
-				err);
+			warning("mcsource: filepath copy failed (%m)\n", err);
+			goto out;
+		}
+
+		err = setup_ausrc_gong(mc_src, mc_src->gong);
+		if (err) {
+			warning ("mcsource: file source setup failed (%m)\n",
+				 err);
 			goto out;
 		}
 	}
 
-	err = aufilt_setup(src, baresip_aufiltl());
-	if (err)
+	debug ("mcsource: setting up audio source\n");
+	err = setup_ausrc_mic(mc_src,
+			      ausrc_find(baresip_ausrcl(),
+			      mc_src->cfg->src_mod));
+	if (err) {
+		warning ("mcsource: mic source setup failed (%m)\n", err);
 		goto out;
+	}
 
-	err = start_source(src);
-	if (err)
+	debug ("mcsource: startup transmission\n");
+	err = start_tx(mc_src);
+	if (err) {
+		warning("mcsource: transmission setup failed (%m)\n", err);
 		goto out;
-
-  out:
+	}
+out:
 	if (err)
-		mem_deref(src);
+		mem_deref(mc_src);
 	else
-		*srcp = src;
+		*srcp = mc_src;
 
 	return err;
 }

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -354,6 +354,8 @@ static int tx_thread(void *arg)
 		     aufmt_sample_size(src->mic_prm.fmt);
 	uint64_t ts = 0;
 
+	debug("mcsource: enter tx_thread loop\n");
+
 	while (re_atomic_rlx(&src->thr.run)) {
 		uint64_t now;
 		sys_msleep(4);
@@ -597,7 +599,6 @@ static int start_tx(struct mcsource *src)
 	if (!src)
 		return EINVAL;
 
-	debug("mcsource: startup tx_thread\n");
 	re_atomic_rlx_set(&src->thr.run, true);
 	err = thread_create_name(&src->thr.tid, "mcsource",
 					tx_thread, src);

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -174,8 +174,9 @@ static int poll_aubuf_tx(struct mcsource *src)
 	}
 
 	aubuf_read_auframe(src->aubuf, &af);
-	if (af.srate != src->ac->srate) {
-		if (af.srate != src->resamp.irate) {
+	if (af.srate != src->ac->srate || af.ch != src->ac->ch) {
+		if (af.srate != src->resamp.irate ||
+		    af.ch != src->resamp.ich) {
 			debug ("mcsource: resampling resetup needed "
 				"(%u:%u -> %u:%u)\n",
 				af.srate, af.ch, src->ac->srate, src->ac->ch);

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -155,7 +155,7 @@ out:
  *
  * @return 0 if success, otherwise errorcode
  */
-static int poll_aubuf_tx(struct mcsource *src)
+static int send_aubuf(struct mcsource *src)
 {
 	struct auframe af;
 	size_t sampc = 0;
@@ -209,7 +209,7 @@ static int poll_aubuf_tx(struct mcsource *src)
 
 
 /**
- * Audio source error handler (file)
+ * Audio source error handler (mic)
  *
  * @param err Error code
  * @param str Error reason
@@ -220,7 +220,10 @@ static void src_mic_err_handler(int err, const char *str, void *arg)
 	struct mcsource *src = arg;
 	(void) src;
 	(void) str;
-	(void) err;
+
+	if (err) {
+		warning("mcsource: mic source (&m)\n", err);
+	}
 }
 
 
@@ -302,7 +305,7 @@ static void src_gong_err_handler(int err, const char *str, void *arg)
 
 
 /**
- * Audio source read handler (file)
+ * Audio source read handler (gong)
  *
  * @param af  Audio frame
  * @param arg Handler argument
@@ -355,7 +358,7 @@ static int tx_thread(void *arg)
 
 		mtx_lock(&src->lock);
 		if (aubuf_cur_size(src->aubuf) >= sz)
-			poll_aubuf_tx(src);
+			send_aubuf(src);
 		mtx_unlock(&src->lock);
 
 		ts += PTIME;

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -598,6 +598,7 @@ static int start_tx(struct mcsource *src)
 	if (!src)
 		return EINVAL;
 
+	debug("mcsource: startup tx_thread\n");
 	re_atomic_rlx_set(&src->thr.run, true);
 	err = thread_create_name(&src->thr.tid, "mcsource",
 					tx_thread, src);
@@ -645,14 +646,12 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 
 	mc_src->cfg = &conf_config()->audio;
 
-	debug ("mcsource: setting up audio encoder %s\n", ac->name);
 	err = setup_aucodec(mc_src, ac);
 	if (err) {
 		warning ("mcsource: codec setup failed (%m)\n", err);
 		goto out;
 	}
 
-	debug ("mcsource: setting up and allocation of buffers\n");
 	err = setup_buffers(mc_src);
 	if (err) {
 		warning("mcsource: failed to allocate necessary buffers "
@@ -665,10 +664,8 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 	mc_src->arg = arg;
 	mc_src->ts_ext = mc_src->ts_base = rand_u32();
 
-	debug ("mcsource: initialize resampler\n");
 	auresamp_init(&mc_src->resamp);
 
-	debug ("mcsource: setting up audio filter in applied order\n");
 	err = setup_aufilt(mc_src, baresip_aufiltl());
 	if (err) {
 		warning ("mcsource: audio filter setup failed (%m) \n", err);
@@ -677,7 +674,6 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 
 	re_atomic_rlx_set(&mc_src->eof, true);
 	if (pl_isset(gong)) {
-		debug ("mcsource: setting up file source for pre-gong\n");
 		re_atomic_rlx_set(&mc_src->eof, false);
 		re_atomic_rlx_set(&mc_src->mic_muted, true);
 		err = pl_strdup(&mc_src->gong, gong);
@@ -694,7 +690,6 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 		}
 	}
 
-	debug ("mcsource: setting up audio source\n");
 	err = setup_ausrc_mic(mc_src,
 			      ausrc_find(baresip_ausrcl(),
 			      mc_src->cfg->src_mod));
@@ -703,7 +698,6 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 		goto out;
 	}
 
-	debug ("mcsource: startup transmission\n");
 	err = start_tx(mc_src);
 	if (err) {
 		warning("mcsource: transmission setup failed (%m)\n", err);


### PR DESCRIPTION
- This PR allows to transmit an audio file as signal before the actual microphone data gets transmitted.
- The feature is controlled via `/mcsend addr=<ADDR> codec=<CODEC> gong=<ABSOLUTE PATH>`. The argument is optional.
- In addition the audio file is played on the local instance as an acoustic signal for the user. 
- The local playback is only initiated for multicast sender when no other sender is active.

